### PR TITLE
Updated to properly use ` for string literals

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -10,7 +10,7 @@ class StopButtonToggle extends Button {
   }
 
   buildCSSClass() {
-    return 'vjs-stop-button vjs-icon-square vjs-button vjs-control ${super.buildCSSClass()}';
+    return `vjs-stop-button vjs-icon-square vjs-button vjs-control ${super.buildCSSClass()}`;
   }
 
   handleClick() {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals 

The code uses ' which just adds the string ${super.buildCSSClass()} to the class list. Updating to ` will properly call `super.buildCSSClass()` and insert that as part of the string.
